### PR TITLE
Enable interactive bounding box editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Annotator
 
-Simple web application for drawing bounding boxes on images.
+Simple web application for drawing and editing bounding boxes on images.
 
 ## Setup
 
@@ -14,5 +14,7 @@ Place images you want to annotate in `static/images` and then run:
 python app.py
 ```
 
-Open `http://localhost:5000/` in your browser to start annotating. Bounding
-boxes are saved as JSON in the `annotations` folder.
+Open `http://localhost:5000/` in your browser to start annotating. Use the
+mouse to create, select and resize boxes. Press the <kbd>Delete</kbd> key to
+remove a selected box. Bounding boxes are saved as JSON in the `annotations`
+folder.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ python app.py
 ```
 
 Open `http://localhost:5000/` in your browser to start annotating. Use the
-mouse to create, select and resize boxes. Press the <kbd>Delete</kbd> key to
-remove a selected box. Bounding boxes are saved as JSON in the `annotations`
-folder.
+mouse to create, select and resize boxes. Hover near a box corner until the
+cursor changes to resize it. Press the <kbd>Delete</kbd> key to remove a
+selected box. Bounding boxes are saved as JSON in the `annotations` folder.

--- a/static/index.html
+++ b/static/index.html
@@ -13,6 +13,7 @@
     <button onclick="save()">Save</button>
     <button onclick="nextImage()">Next</button>
   </div>
+  <p>Draw with mouse. Click boxes to move or resize. Press Delete to remove.</p>
   <script src="/static/script.js"></script>
 </body>
 </html>

--- a/static/script.js
+++ b/static/script.js
@@ -2,7 +2,33 @@ let images = [];
 let currentIndex = 0;
 let boxes = [];
 let canvas, ctx, img;
-let startX, startY, isDrawing = false;
+let startX, startY;
+let isDragging = false;
+let action = null; // 'draw', 'move', 'resize'
+let selected = -1;
+let dragOffsetX = 0, dragOffsetY = 0;
+let startBox = null;
+let resizeHandle = null;
+const handleSize = 6;
+
+function pointInBox(x, y, b){
+  return x >= b.x && y >= b.y && x <= b.x + b.w && y <= b.y + b.h;
+}
+
+function handleAt(x, y, b){
+  const handles = {
+    nw: [b.x, b.y],
+    ne: [b.x + b.w, b.y],
+    sw: [b.x, b.y + b.h],
+    se: [b.x + b.w, b.y + b.h]
+  };
+  for(let h in handles){
+    const [hx, hy] = handles[h];
+    if(Math.abs(x - hx) <= handleSize && Math.abs(y - hy) <= handleSize)
+      return h;
+  }
+  return null;
+}
 
 function fetchImages(){
   fetch('/images').then(r => r.json()).then(list => {
@@ -31,9 +57,21 @@ function loadImage(index){
 function draw(){
   ctx.clearRect(0,0,canvas.width,canvas.height);
   if(img) ctx.drawImage(img,0,0);
-  ctx.strokeStyle = 'red';
-  boxes.forEach(b => {
+  boxes.forEach((b, i) => {
+    ctx.strokeStyle = i === selected ? 'blue' : 'red';
     ctx.strokeRect(b.x, b.y, b.w, b.h);
+    if(i === selected){
+      ctx.fillStyle = 'blue';
+      const corners = [
+        [b.x, b.y],
+        [b.x + b.w, b.y],
+        [b.x, b.y + b.h],
+        [b.x + b.w, b.y + b.h]
+      ];
+      corners.forEach(c => {
+        ctx.fillRect(c[0] - handleSize/2, c[1] - handleSize/2, handleSize, handleSize);
+      });
+    }
   });
 }
 
@@ -64,22 +102,88 @@ window.onload = () => {
   canvas.onmousedown = (e) => {
     startX = e.offsetX;
     startY = e.offsetY;
-    isDrawing = true;
+
+    // check existing boxes from topmost
+    selected = -1;
+    for(let i = boxes.length - 1; i >= 0; i--){
+      if(pointInBox(startX, startY, boxes[i])){
+        selected = i;
+        break;
+      }
+    }
+
+    if(selected !== -1){
+      const handle = handleAt(startX, startY, boxes[selected]);
+      startBox = {...boxes[selected]};
+      if(handle){
+        action = 'resize';
+        dragOffsetX = startX;
+        dragOffsetY = startY;
+        resizeHandle = handle;
+      }else{
+        action = 'move';
+        dragOffsetX = startX - boxes[selected].x;
+        dragOffsetY = startY - boxes[selected].y;
+      }
+      isDragging = true;
+    }else{
+      action = 'draw';
+      isDragging = true;
+      boxes.push({x:startX, y:startY, w:0, h:0});
+      selected = boxes.length - 1;
+    }
+    draw();
   };
 
   canvas.onmousemove = (e) => {
-    if(!isDrawing) return;
+    if(!isDragging) return;
+    const box = boxes[selected];
+    if(action === 'draw'){
+      box.w = e.offsetX - startX;
+      box.h = e.offsetY - startY;
+    }else if(action === 'move'){
+      box.x = e.offsetX - dragOffsetX;
+      box.y = e.offsetY - dragOffsetY;
+    }else if(action === 'resize'){
+      switch(resizeHandle){
+        case 'nw':
+          box.x = e.offsetX;
+          box.y = e.offsetY;
+          box.w = startBox.w + (startBox.x - e.offsetX);
+          box.h = startBox.h + (startBox.y - e.offsetY);
+          break;
+        case 'ne':
+          box.y = e.offsetY;
+          box.w = e.offsetX - startBox.x;
+          box.h = startBox.h + (startBox.y - e.offsetY);
+          break;
+        case 'sw':
+          box.x = e.offsetX;
+          box.w = startBox.w + (startBox.x - e.offsetX);
+          box.h = e.offsetY - startBox.y;
+          break;
+        case 'se':
+          box.w = e.offsetX - startBox.x;
+          box.h = e.offsetY - startBox.y;
+          break;
+      }
+    }
     draw();
-    ctx.strokeStyle = 'lime';
-    ctx.strokeRect(startX, startY, e.offsetX - startX, e.offsetY - startY);
   };
 
-  canvas.onmouseup = (e) => {
-    if(!isDrawing) return;
-    isDrawing = false;
-    boxes.push({x:startX, y:startY, w:e.offsetX - startX, h:e.offsetY - startY});
-    draw();
+  canvas.onmouseup = () => {
+    isDragging = false;
+    action = null;
+    startBox = null;
   };
+
+  window.addEventListener('keydown', (e) => {
+    if((e.key === 'Delete' || e.key === 'Backspace') && selected !== -1){
+      boxes.splice(selected,1);
+      selected = -1;
+      draw();
+    }
+  });
 
   fetchImages();
 };

--- a/static/script.js
+++ b/static/script.js
@@ -9,10 +9,15 @@ let selected = -1;
 let dragOffsetX = 0, dragOffsetY = 0;
 let startBox = null;
 let resizeHandle = null;
-const handleSize = 6;
+const handleSize = 6;      // visible corner square
+const handleHitSize = 12;  // larger area for easier grabbing
 
 function pointInBox(x, y, b){
-  return x >= b.x && y >= b.y && x <= b.x + b.w && y <= b.y + b.h;
+  const x1 = Math.min(b.x, b.x + b.w);
+  const y1 = Math.min(b.y, b.y + b.h);
+  const x2 = Math.max(b.x, b.x + b.w);
+  const y2 = Math.max(b.y, b.y + b.h);
+  return x >= x1 && y >= y1 && x <= x2 && y <= y2;
 }
 
 function handleAt(x, y, b){
@@ -24,10 +29,23 @@ function handleAt(x, y, b){
   };
   for(let h in handles){
     const [hx, hy] = handles[h];
-    if(Math.abs(x - hx) <= handleSize && Math.abs(y - hy) <= handleSize)
+    if(Math.abs(x - hx) <= handleHitSize/2 && Math.abs(y - hy) <= handleHitSize/2)
       return h;
   }
   return null;
+}
+
+function cursorForHandle(h){
+  switch(h){
+    case 'nw':
+    case 'se':
+      return 'nwse-resize';
+    case 'ne':
+    case 'sw':
+      return 'nesw-resize';
+    default:
+      return 'default';
+  }
 }
 
 function fetchImages(){
@@ -120,15 +138,18 @@ window.onload = () => {
         dragOffsetX = startX;
         dragOffsetY = startY;
         resizeHandle = handle;
+        canvas.style.cursor = cursorForHandle(handle);
       }else{
         action = 'move';
         dragOffsetX = startX - boxes[selected].x;
         dragOffsetY = startY - boxes[selected].y;
+        canvas.style.cursor = 'move';
       }
       isDragging = true;
     }else{
       action = 'draw';
       isDragging = true;
+      canvas.style.cursor = 'crosshair';
       boxes.push({x:startX, y:startY, w:0, h:0});
       selected = boxes.length - 1;
     }
@@ -136,45 +157,66 @@ window.onload = () => {
   };
 
   canvas.onmousemove = (e) => {
-    if(!isDragging) return;
-    const box = boxes[selected];
-    if(action === 'draw'){
-      box.w = e.offsetX - startX;
-      box.h = e.offsetY - startY;
-    }else if(action === 'move'){
-      box.x = e.offsetX - dragOffsetX;
-      box.y = e.offsetY - dragOffsetY;
-    }else if(action === 'resize'){
-      switch(resizeHandle){
-        case 'nw':
-          box.x = e.offsetX;
-          box.y = e.offsetY;
-          box.w = startBox.w + (startBox.x - e.offsetX);
-          box.h = startBox.h + (startBox.y - e.offsetY);
-          break;
-        case 'ne':
-          box.y = e.offsetY;
-          box.w = e.offsetX - startBox.x;
-          box.h = startBox.h + (startBox.y - e.offsetY);
-          break;
-        case 'sw':
-          box.x = e.offsetX;
-          box.w = startBox.w + (startBox.x - e.offsetX);
-          box.h = e.offsetY - startBox.y;
-          break;
-        case 'se':
-          box.w = e.offsetX - startBox.x;
-          box.h = e.offsetY - startBox.y;
-          break;
+    if(isDragging){
+      const box = boxes[selected];
+      if(action === 'draw'){
+        box.w = e.offsetX - startX;
+        box.h = e.offsetY - startY;
+      }else if(action === 'move'){
+        box.x = e.offsetX - dragOffsetX;
+        box.y = e.offsetY - dragOffsetY;
+      }else if(action === 'resize'){
+        switch(resizeHandle){
+          case 'nw':
+            box.x = e.offsetX;
+            box.y = e.offsetY;
+            box.w = startBox.w + (startBox.x - e.offsetX);
+            box.h = startBox.h + (startBox.y - e.offsetY);
+            break;
+          case 'ne':
+            box.y = e.offsetY;
+            box.w = e.offsetX - startBox.x;
+            box.h = startBox.h + (startBox.y - e.offsetY);
+            break;
+          case 'sw':
+            box.x = e.offsetX;
+            box.w = startBox.w + (startBox.x - e.offsetX);
+            box.h = e.offsetY - startBox.y;
+            break;
+          case 'se':
+            box.w = e.offsetX - startBox.x;
+            box.h = e.offsetY - startBox.y;
+            break;
+        }
       }
+      draw();
+    }else{
+      let cur = 'crosshair';
+      for(let i = boxes.length - 1; i >= 0; i--){
+        const handle = handleAt(e.offsetX, e.offsetY, boxes[i]);
+        if(handle){
+          cur = cursorForHandle(handle);
+          break;
+        }
+        if(pointInBox(e.offsetX, e.offsetY, boxes[i])){
+          cur = 'move';
+          break;
+        }
+      }
+      canvas.style.cursor = cur;
     }
-    draw();
   };
 
   canvas.onmouseup = () => {
+    if((action === 'draw' || action === 'resize') && boxes[selected]){
+      const b = boxes[selected];
+      if(b.w < 0){ b.x += b.w; b.w = Math.abs(b.w); }
+      if(b.h < 0){ b.y += b.h; b.h = Math.abs(b.h); }
+    }
     isDragging = false;
     action = null;
     startBox = null;
+    canvas.style.cursor = 'crosshair';
   };
 
   window.addEventListener('keydown', (e) => {

--- a/static/style.css
+++ b/static/style.css
@@ -1,3 +1,3 @@
 body { font-family: Arial, sans-serif; }
-canvas { border: 1px solid #000; display:block; margin-bottom:10px; }
+canvas { border: 1px solid #000; display:block; margin-bottom:10px; cursor: crosshair; }
 #controls { margin-top:10px; }


### PR DESCRIPTION
## Summary
- allow creating, selecting and resizing bounding boxes
- support moving and deleting boxes
- show editing controls on the page

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684b109ae4148321aa93194304441b74